### PR TITLE
Add a projects page

### DIFF
--- a/00-projects.md
+++ b/00-projects.md
@@ -6,6 +6,7 @@ title: "Projects"
 
 * [Source code](https://github.com/geojupyter/jupytergis)
 * [Try it now!](https://jupytergis.readthedocs.io/en/latest/lite/lab/)
+* [Priorities](https://github.com/orgs/geojupyter/projects/2)
 
 
 ## [Workshops](https://workshops.geojupyter.org)

--- a/00-projects.md
+++ b/00-projects.md
@@ -1,0 +1,11 @@
+---
+title: "Projects"
+---
+
+## [JupyterGIS](https://jupytergis.readthedocs.io/)
+
+* [Source code](https://github.com/geojupyter/jupytergis)
+* [Try it now!](https://jupytergis.readthedocs.io/en/latest/lite/lab/)
+
+
+## [Workshops](https://workshops.geojupyter.org)


### PR DESCRIPTION
Are there any links we should add for JupyterGIS?

<!-- readthedocs-preview geojupyter-workshop-csdms2025 start -->
---
:mag: Preview: https://geojupyter-workshop-csdms2025--3.org.readthedocs.build/en/3/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-csdms2025 end -->