### PR TITLE
Build on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,4 @@ build:
     build:
       html:
         - "myst build --strict --html"
-        - "mv ./_build/html ${READTHEDOCS_OUTPUT}/."  
+        - "mv ./_build/html ${READTHEDOCS_OUTPUT}/."

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,5 @@ build:
     build:
       html:
         - "myst build --strict --html"
-        - "mv ./_build/html ${READTHEDOCS_OUTPUT}/."
+        - "mkdir --parents $READTHEDOCS_OUTPUT/html/"
+        - "mv ./_build/html/* ${READTHEDOCS_OUTPUT}/html/."

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
     build:
       html:
         - "myst build --strict --html"
-        - "mkdir --parents $READTHEDOCS_OUTPUT/html/"
-        - "mv ./_build/html/* ${READTHEDOCS_OUTPUT}/html/."
+        - "mkdir --parents $READTHEDOCS_OUTPUT"
+        - "mv ./_build/html ${READTHEDOCS_OUTPUT}/."
+        - "ls -la ${READTHEDOCS_OUTPUT}/html"
         - "rm -rf _build"  # RTD build fails if _build/html is detected :(

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+# For this project, we use ReadTheDocs only for Pull Request previews. GitHub
+# pages currently hosts the actual website.
+version: 2
+
+
+build:
+  os: "ubuntu-lts-latest"
+  tools:
+    nodejs: "22"
+  jobs:
+    post_install:
+      - "npm install -g mystmd"
+    build:
+      html:
+        - "mystmd build --strict --html"
+        - "mv ./_build/html ${READTHEDOCS_OUTPUT}/."  

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,5 @@ build:
       - "npm install -g mystmd"
     build:
       html:
-        - "mystmd build --strict --html"
+        - "myst build --strict --html"
         - "mv ./_build/html ${READTHEDOCS_OUTPUT}/."  

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,4 @@ build:
         - "myst build --strict --html"
         - "mkdir --parents $READTHEDOCS_OUTPUT/html/"
         - "mv ./_build/html/* ${READTHEDOCS_OUTPUT}/html/."
+        - "rm -rf _build"  # RTD build fails if _build/html is detected :(


### PR DESCRIPTION
I'm thinking of having the whole site on RTD instead of GH Pages. For now, it will exist on both while I play around with custom domain!

<!-- readthedocs-preview geojupyter-workshop-csdms2025 start -->
---
:mag: Preview: https://geojupyter-workshop-csdms2025--4.org.readthedocs.build/en/4/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-workshop-csdms2025 end -->