### PR TITLE
Migrate 8/5 jupytergis sync meeting notes, update sync template

### DIFF
--- a/.github/meeting-notes-templates/jupytergis-sync.md
+++ b/.github/meeting-notes-templates/jupytergis-sync.md
@@ -13,13 +13,13 @@ categories:
 tags: [jupytergis-notes]
 ---
 
-:::info {.callout-info}
-:mag: This meeting is _short_ and _task-focused_. Unfortunately, we won't have time to
-introduce every new person to the team. Please attend core community meetings ([see
-GeoJupyter calendar](https://geojupyter.org/calendar)) to meet the team and add your own
-agenda items, and/or
-[introduce yourself on Zulip](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter/topic/Welcome)!
-:::
+> :pray: **Our apologies, there's no time for introductions!**
+>
+> We're excited for you to join us, but this meeting is _short_ and _task-focused_.
+> Please attend core community meetings
+> ([see GeoJupyter calendar](https://geojupyter.org/calendar))
+> to meet the team and add your own agenda items, and/or
+> [introduce yourself on  Zulip](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter/topic/Welcome)!
 
 # JupyterGIS sync meeting ({{ date.strftime("%Y-%m-%d") }})
 

--- a/meeting-notes/20250805-jupytergis-sync/index.md
+++ b/meeting-notes/20250805-jupytergis-sync/index.md
@@ -1,0 +1,54 @@
+---
+title: "JupyterGIS sync meeting"
+description: |
+  A weekly gathering of JupyterGIS team to discuss our progress and help each other out.
+  Open to all, but this meeting is _short_ and task-focused, so there will not be time
+  for introductions. Please join a core meeting!
+date: "2025-08-05"
+image: "../images/standup.jpg"
+author:
+  - name: "The GeoJupyter community"
+categories:
+  - "JupyterGIS notes"
+tags: [jupytergis-notes]
+---
+
+> :pray: **Our apologies, there's no time for introductions!**
+>
+> We're excited for you to join us, but this meeting is _short_ and _task-focused_.
+> Please attend core community meetings
+> ([see GeoJupyter calendar](https://geojupyter.org/calendar))
+> to meet the team and add your own agenda items, and/or
+> [introduce yourself on  Zulip](https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter/topic/Welcome)!
+
+# JupyterGIS sync meeting (2025-08-05)
+
+Please add new agenda items under the `New agenda items` heading!
+
+- [Join us on Google Meet](https://meet.google.com/zhk-vygf-gke)
+  - [What time is the meeting in my time zone?](https://dateful.com/convert/utc?t=3pm)
+- [Previous meetings](https://geojupyter.org/blog/#category=JupyterGIS%20notes)
+
+
+## Attendees
+
+Your name / GitHub ID / affiliation
+
+* Arjun Verma / @arjxn-py / QuantStack
+* Matt Fisher / @mfisher / DSE
+
+
+## Agenda
+
+* Review our [project board](https://github.com/orgs/geojupyter/projects/2)
+  * What items should be added?
+  * Are there stale items that are no longer urgent?
+  * Are there things we can change about the project board to make it more useful? Add more information? Remove steps?
+* _Please add more items if you have them!_
+
+
+### Status reports
+
+* https://github.com/geojupyter/jupytergis/issues/846 - Why is jupyter-collab pinned <4? Seems safe to upgrade.
+* https://github.com/geojupyter/jupytergis/pull/844 - vectortile symbology!! Ready for review.
+* Matt & Arjun: Make sure Arjun has privileges release by doing a release together (Friday?)!


### PR DESCRIPTION


<!-- readthedocs-preview geojupyter-team-compass start -->
---
:mag: Preview: https://geojupyter-team-compass--13.org.readthedocs.build/en/13/
_Note: This Pull Request preview is provided by ReadTheDocs. Our production website, however, is currently deployed with GitHub Pages._

<!-- readthedocs-preview geojupyter-team-compass end -->